### PR TITLE
Publish tf_static more frequently

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -149,7 +149,7 @@ protected:
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
   /// A pointer to the tf2 StaticTransformBroadcaster
-  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
+  // std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
 
   /// A pointer to the ROS 2 publisher for the robot_description
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr description_pub_;
@@ -157,6 +157,9 @@ protected:
   /// A pointer to the ROS 2 subscription for the joint states
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_sub_;
 
+  /// A timer to publish static transforms
+  rclcpp::TimerBase::SharedPtr timer_;
+  
   /// The last time a joint state message was received
   rclcpp::Time last_callback_time_;
 

--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -149,7 +149,7 @@ protected:
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
   /// A pointer to the tf2 StaticTransformBroadcaster
-  // std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
+  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
 
   /// A pointer to the ROS 2 publisher for the robot_description
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr description_pub_;

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -127,7 +127,6 @@ RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
   this->declare_parameter("ignore_timestamp", false);
 
   tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(this);
-  
   static_tf_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(this);
 
   description_pub_ = this->create_publisher<std_msgs::msg::String>(
@@ -149,15 +148,17 @@ RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
     subscriber_options);
 
   // Set static pubish frequency
-  double static_publish_freq = this->declare_parameter("static_publish_frequency", 0.5);
+  double static_publish_freq = this->declare_parameter("static_publish_frequency", 1.0);
   RCLCPP_INFO(this->get_logger(), "Static TF publish frequency set to: %f",static_publish_freq);
-  
+
   // Create a timer to publish static tfs
   auto static_publish_interval_ms_= std::chrono::milliseconds(static_cast<uint64_t>(1000.0 / static_publish_freq));
 
   timer_ = this->create_wall_timer(static_publish_interval_ms_,
                                    std::bind(&RobotStatePublisher::publishFixedTransforms, this));
 
+  // Make sure fixed TFs are published immediately
+  publishFixedTransforms();
 
   // Now that we have successfully declared the parameters and done all
   // necessary setup, install the callback for updating parameters.


### PR DESCRIPTION
- Add a timer to publish `tf_static` at the frequency set by the `static_publish_frequency` parameter.
- Improve `tf_static` capture in ROSbags, especially when using the splitting feature.
